### PR TITLE
migrated to github/ros and updated checksum

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ros-melodic-pluginlib
 	pkgdesc = ROS - The pluginlib package provides tools for writing and dynamically loading plugins using the ROS build infrastructure.
-	pkgver = 1.12.1
+	pkgver = 2.3.0
 	pkgrel = 1
 	url = http://www.ros.org/wiki/pluginlib
 	arch = any
@@ -19,8 +19,8 @@ pkgbase = ros-melodic-pluginlib
 	depends = ros-melodic-roslib
 	depends = boost
 	depends = tinyxml2
-	source = ros-melodic-pluginlib-1.12.1-0.tar.gz::https://github.com/ros-gbp/pluginlib-release/archive/release/melodic/pluginlib/1.12.1-0.tar.gz
-	sha256sums = d126b9eae7db607fb84b1cb56ac2db9862ebca48ba99a47a9f502689bea83eba
+	source = ros-melodic-pluginlib-2.3.0.tar.gz::https://github.com/ros/pluginlib/archive/pluginlib/2.3.0.tar.gz
+	sha256sums = 8fede085c83d4b7f1fcde454f364e04cfc5680ab41ac7029f9bbaf53ff6e5a07
 
 pkgname = ros-melodic-pluginlib
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgdesc="ROS - The pluginlib package provides tools for writing and dynamically 
 url='http://www.ros.org/wiki/pluginlib'
 
 pkgname='ros-melodic-pluginlib'
-pkgver='1.12.1'
+pkgver='2.3.0'
 _pkgver_patch=0
 arch=('any')
 pkgrel=1
@@ -39,8 +39,8 @@ depends=(
 )
 
 _dir="pluginlib-release-release-melodic-pluginlib"
-source=("${pkgname}-${pkgver}-${_pkgver_patch}.tar.gz"::"https://github.com/ros-gbp/pluginlib-release/archive/release/melodic/pluginlib/${pkgver}-${_pkgver_patch}.tar.gz")
-sha256sums=('d126b9eae7db607fb84b1cb56ac2db9862ebca48ba99a47a9f502689bea83eba')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/pluginlib/archive/pluginlib/${pkgver}.tar.gz")
+sha256sums=('8fede085c83d4b7f1fcde454f364e04cfc5680ab41ac7029f9bbaf53ff6e5a07')
 
 build() {
 	# Use ROS environment variables.

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,6 @@ url='http://www.ros.org/wiki/pluginlib'
 
 pkgname='ros-melodic-pluginlib'
 pkgver='2.3.0'
-_pkgver_patch=0
 arch=('any')
 pkgrel=1
 license=('BSD')
@@ -38,7 +37,7 @@ depends=(
 	tinyxml2
 )
 
-_dir="pluginlib-release-release-melodic-pluginlib"
+_dir="pluginlib-${pkgver}"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/pluginlib/archive/pluginlib/${pkgver}.tar.gz")
 sha256sums=('8fede085c83d4b7f1fcde454f364e04cfc5680ab41ac7029f9bbaf53ff6e5a07')
 


### PR DESCRIPTION
@bionade24 here's an attempt to address #1 as well as migrate to upstream ROS.

I used your [fix](https://github.com/ros-melodic-arch/ros-melodic-cpp-common/commit/99916cad570004b5d7c5dade0805348c12907855) as a reference, though I kept bash-based package details so we only have to update the header. Namely, the tarball should still reference `pkgver`, not explicitly contain it.

Also, is `pkgrel` obsolete here if we're only tracking releases?

I currently don't have ROS on arch anymore, so sadly I can't easily test this unless I install all the deps. I'll fix that in the next weeks but wanted to help here sooner than later.